### PR TITLE
required order module to Razorpay class

### DIFF
--- a/lib/razorpay.rb
+++ b/lib/razorpay.rb
@@ -1,5 +1,6 @@
 require 'razorpay/constants'
 require 'razorpay/payment'
+require 'razorpay/order'
 
 # Base Razorpay module
 module Razorpay


### PR DESCRIPTION
update `lib/razorpay.rb` with requiring order module. 
