### PR TITLE
New methods to capture and refund payments by id

### DIFF
--- a/lib/razorpay/payment.rb
+++ b/lib/razorpay/payment.rb
@@ -19,8 +19,17 @@ module Razorpay
       request.all options
     end
 
+    def self.capture_id(payment_id, options)
+      raise ArgumentError, 'Please provide capture amount' unless options.key?(:amount)
+      request.post "#{payment_id}/capture", options
+    end
+
+    def self.refund_id(payment_id, options = {})
+      request.post "#{payment_id}/refund", options
+    end
+
     def refund(options = {})
-      self.class.request.post "#{id}/refund", options
+      self.class.refund_id(id, options)
     end
 
     def refunds
@@ -29,8 +38,7 @@ module Razorpay
     end
 
     def capture(options)
-      raise ArgumentError, 'Please provide capture amount' unless options.key?(:amount)
-      self.class.request.post "#{id}/capture", options
+      self.class.capture_id(id, options)
     end
 
     def method

--- a/test/razorpay/test_payment.rb
+++ b/test/razorpay/test_payment.rb
@@ -45,6 +45,12 @@ module Razorpay
       assert_equal refund.payment_id, @payment_id
     end
 
+    def test_payment_refund_id
+      stub_post(%r{payments/#{@payment_id}/refund$}, 'fake_refund', {})
+      refund = Razorpay::Payment.refund_id(@payment_id)
+      assert_equal refund.payment_id, @payment_id
+    end
+
     def test_partial_refund
       # For some reason, stub doesn't work if I pass it a hash of post body
       stub_post(%r{payments/#{@payment_id}/refund$}, 'fake_refund', 'amount=2000')
@@ -61,6 +67,15 @@ module Razorpay
         payment.capture
       end
       payment = payment.capture(amount: 5100)
+      assert_equal 'captured', payment.status
+    end
+
+    def test_payment_capture_id
+      stub_post(%r{payments/#{@payment_id}/capture$}, 'fake_captured_payment', 'amount=5100')
+      assert_raises(ArgumentError, 'ArgumentError should be raised if amount is not provided') do
+        Payment.capture_id(@payment_id, {})
+      end
+      payment = Payment.capture_id(@payment_id, amount: 5100)
       assert_equal 'captured', payment.status
     end
   end


### PR DESCRIPTION
Currently the Razorpay::Payment class has instance methods to capture or
refund payments. Which means one must fetch the payment before capturing
or refunding it. This is costly as it entails two network calls to the
razorpay server.

This patch introduces two class methods that can be used to capture or
refund a payment by passing the payment id as an argument. Examples:

Razorpay::Payment.capture_id(payment_id)
Razorpay::Payment.refund_id(payment_id)