### PR TITLE
Fixed readme typo and rubocop offences

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ card = Razorpay::Card.fetch('card_7EZLhWkDt05n7V')
 puts card.network #VISA
 ```
 
-You can find invoices API documentation at <https://docs.razorpay.com/v1/page/cards>.
+You can find cards API documentation at <https://docs.razorpay.com/v1/page/cards>.
 
 ### Invoices
 ```rb

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ Rake::TestTask.new do |t|
 end
 
 desc 'Run tests'
-task default: [:test, :rubocop]
+task default: %i[test rubocop]
 
 desc 'Run rubocop'
 task :rubocop do

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ Rake::TestTask.new do |t|
 end
 
 desc 'Run tests'
-task default: %i[test rubocop]
+task default: [:test, :rubocop]
 
 desc 'Run rubocop'
 task :rubocop do

--- a/razorpay-ruby.gemspec
+++ b/razorpay-ruby.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'razorpay/constants'


### PR DESCRIPTION
- Fixed a typo in readme
- Used %i for an array of symbols
- Added new line after magic comments