### PR TITLE
[rubocop] Disables SymbolArray cop till MinSize option is added

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,11 @@ Metrics/LineLength:
   Max: 110
   AllowURI: true
 
+# TODO: Enable when rubocop#4262 is released
+Style/SymbolArray:
+  Enabled: false
+  # MinSize: 3
+
 Style/ClassVars:
   Enabled: false
 


### PR DESCRIPTION
Rubocop `0.48` enabled `SymbolArray` Cop by default. It enforces `%i` literals for arrays of symbols, and finds an offence in our Rakefile.

Disabling the cop temporarily, but it should be enabled again when the cop offers a `MinSize` attribute. This has been added in [rucocop#4262](https://github.com/bbatsov/rubocop/pull/4262), currently unreleased.