### PR TITLE
[rubocop] Updates rubocop to 0.49, re-enables SymbolArray cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,8 @@ Metrics/LineLength:
   Max: 110
   AllowURI: true
 
-# TODO: Enable when rubocop#4262 is released
 Style/SymbolArray:
-  Enabled: false
-  # MinSize: 3
+  MinSize: 3
 
 Style/ClassVars:
   Enabled: false

--- a/razorpay-ruby.gemspec
+++ b/razorpay-ruby.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.10'
   spec.add_development_dependency 'webmock', '~> 2.3'
   spec.add_development_dependency 'coveralls', '~> 0.8'
-  spec.add_development_dependency 'rubocop', '~> 0.47'
+  spec.add_development_dependency 'rubocop', '~> 0.49'
   spec.add_dependency 'httparty', '~> 0.14'
 end


### PR DESCRIPTION
We'd [disabled](https://github.com/razorpay/razorpay-ruby/pull/33) SymbolArray until Rubocop added [MinSize for SymbolArray cops](https://github.com/bbatsov/rubocop/pull/4262). 

This was released in [0.49](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0490-2017-05-24).