### PR TITLE
[utility] Allows custom secret for webhook validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ puts payment_response
 # }
 Razorpay::Utility.verify_payment_signature(payment_response)
 ```
+You can also verify the signature received in a webhook:
+```rb
+Razorpay::Utility.verify_webhook_signature(webhook_signature, webhook_body, webhook_secret)
+```
 
 ### Customers
 ```rb

--- a/lib/razorpay/utility.rb
+++ b/lib/razorpay/utility.rb
@@ -10,19 +10,19 @@ module Razorpay
 
       data = [order_id, payment_id].join '|'
 
-      verify_signature(signature, data)
+      secret = Razorpay.auth[:password]
+
+      verify_signature(signature, data, secret)
     end
 
-    def self.verify_webhook_signature(signature, body)
-      verify_signature(signature, body)
+    def self.verify_webhook_signature(signature, body, secret)
+      verify_signature(signature, body, secret)
     end
 
     class << self
       private
 
-      def verify_signature(signature, data)
-        secret = Razorpay.auth[:password]
-
+      def verify_signature(signature, data, secret)
         expected_signature = OpenSSL::HMAC.hexdigest('SHA256', secret, data)
 
         verified = secure_compare(expected_signature, signature)

--- a/test/razorpay/test_utility.rb
+++ b/test/razorpay/test_utility.rb
@@ -23,12 +23,13 @@ module Razorpay
 
     def test_webhook_signature_verification
       webhook_body = fixture_file('fake_payment_authorized_webhook')
-      signature = 'd60e67fd884556c045e9be7dad57903e33efc7172c17c6e3ef77db42d2b366e9'
-      Razorpay::Utility.verify_webhook_signature(signature, webhook_body)
+      secret = 'chosen_webhook_secret'
+      signature = 'dda9ca344c56ccbd90167b1be0fd99dfa92fe2b827020f27e2a46024e31c7c99'
+      Razorpay::Utility.verify_webhook_signature(signature, webhook_body, secret)
 
       signature = '_dummy_signature' * 4
       assert_raises(SecurityError) do
-        Razorpay::Utility.verify_webhook_signature(signature, webhook_body)
+        Razorpay::Utility.verify_webhook_signature(signature, webhook_body, secret)
       end
     end
   end


### PR DESCRIPTION
 - Webhook validation currently uses merchant API secret by default for signature generation.
 - Method now accepts secret as input, so a different secret can be used for webhooks