### PR TITLE
[utility] Changes method signature to match other SDKs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,11 @@ Changelog for Razorpay-Ruby SDK.
 
 ## Unreleased
 
-## [2.0.0] - 2016-03-02
+## [2.0.1] - 2017-07-31
+### Fixed
+- Webhook signature verification
+
+## [2.0.0] - 2017-03-02
 ### Added
 - Adds `require` for all Razorpay supported entities
 - All entity objects now throw `NoMethodError` instead of `NameError` if the attribute doesn't exist
@@ -46,7 +50,8 @@ Changelog for Razorpay-Ruby SDK.
 ### Added
 - Initial Release
 
-[Unreleased]: https://github.com/razorpay/razorpay-ruby/compare/2.0.0...HEAD
+[Unreleased]: https://github.com/razorpay/razorpay-ruby/compare/2.0.1...HEAD
+[2.0.1]: https://github.com/razorpay/razorpay-ruby/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/razorpay/razorpay-ruby/compare/1.2.1...2.0.0
 [1.2.1]: https://github.com/razorpay/razorpay-ruby/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/razorpay/razorpay-ruby/compare/1.1.0...1.2.0

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ puts payment_response
 # }
 Razorpay::Utility.verify_payment_signature(payment_response)
 ```
-You can also verify the signature received in a webhook:
+You can also [verify the signature](https://github.com/razorpay/razorpay-ruby/wiki/Webhooks) received in a webhook:
 ```rb
 Razorpay::Utility.verify_webhook_signature(webhook_body, webhook_signature, webhook_secret)
 ```

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Razorpay::Utility.verify_payment_signature(payment_response)
 ```
 You can also verify the signature received in a webhook:
 ```rb
-Razorpay::Utility.verify_webhook_signature(webhook_signature, webhook_body, webhook_secret)
+Razorpay::Utility.verify_webhook_signature(webhook_body, webhook_signature, webhook_secret)
 ```
 
 ### Customers

--- a/lib/razorpay/constants.rb
+++ b/lib/razorpay/constants.rb
@@ -2,5 +2,5 @@
 module Razorpay
   BASE_URI = 'https://api.razorpay.com/v1/'.freeze
   TEST_URL = 'https://api.razorpay.com/'.freeze
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 end

--- a/lib/razorpay/utility.rb
+++ b/lib/razorpay/utility.rb
@@ -12,17 +12,17 @@ module Razorpay
 
       secret = Razorpay.auth[:password]
 
-      verify_signature(signature, data, secret)
+      verify_signature(data, signature, secret)
     end
 
-    def self.verify_webhook_signature(signature, body, secret)
-      verify_signature(signature, body, secret)
+    def self.verify_webhook_signature(body, signature, secret)
+      verify_signature(body, signature, secret)
     end
 
     class << self
       private
 
-      def verify_signature(signature, data, secret)
+      def verify_signature(data, signature, secret)
         expected_signature = OpenSSL::HMAC.hexdigest('SHA256', secret, data)
 
         verified = secure_compare(expected_signature, signature)

--- a/razorpay-ruby.gemspec
+++ b/razorpay-ruby.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'razorpay'
   spec.version       = Razorpay::VERSION
   spec.authors       = ['Abhay Rana', 'Harman Singh']
-  spec.email         = ['nemo@razorpay.com']
+  spec.email         = ['nemo@razorpay.com', 'harman@razorpay.com']
   spec.summary       = "Razorpay's Ruby API"
   spec.description   = 'Official ruby bindings for the Razorpay API'
   spec.homepage      = 'https://razorpay.com/'

--- a/test/razorpay/test_utility.rb
+++ b/test/razorpay/test_utility.rb
@@ -25,11 +25,11 @@ module Razorpay
       webhook_body = fixture_file('fake_payment_authorized_webhook')
       secret = 'chosen_webhook_secret'
       signature = 'dda9ca344c56ccbd90167b1be0fd99dfa92fe2b827020f27e2a46024e31c7c99'
-      Razorpay::Utility.verify_webhook_signature(signature, webhook_body, secret)
+      Razorpay::Utility.verify_webhook_signature(webhook_body, signature, secret)
 
       signature = '_dummy_signature' * 4
       assert_raises(SecurityError) do
-        Razorpay::Utility.verify_webhook_signature(signature, webhook_body, secret)
+        Razorpay::Utility.verify_webhook_signature(webhook_body, signature, secret)
       end
     end
   end


### PR DESCRIPTION
PHP, Java, and .NET follow `body-signature-secret`, while Ruby and Python were following `signature-body-secret`. With the recent bugfix (#36), we have a chance to fix and make this consistent without requiring a major release.