### PR TITLE
[rubocop] Removes useless utf8 encoding statement

### DIFF
--- a/razorpay-ruby.gemspec
+++ b/razorpay-ruby.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'razorpay/constants'


### PR DESCRIPTION
[Builds have been failing](https://travis-ci.org/razorpay/razorpay-ruby/builds) since Rubocop's [last release](https://github.com/bbatsov/rubocop/releases/tag/v0.50.0). Changelog says the [Style/Encoding cop](http://www.rubydoc.info/github/bbatsov/rubocop/Rubocop/Cop/Style/Encoding) was [enabled by default](https://github.com/bbatsov/rubocop/pull/4445). 

Makes sense according to docs, apparently utf-8 has been default source file encoding since Ruby 2.0