### PR TITLE
[rubocop] Arranges dependencies in alpbhetical order

### DIFF
--- a/razorpay-ruby.gemspec
+++ b/razorpay-ruby.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)/)
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'minitest', '~> 5.10'
-  spec.add_development_dependency 'webmock', '~> 2.3'
   spec.add_development_dependency 'coveralls', '~> 0.8'
+  spec.add_development_dependency 'minitest', '~> 5.10'
+  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rubocop', '~> 0.49'
+  spec.add_development_dependency 'webmock', '~> 2.3'
   spec.add_dependency 'httparty', '~> 0.14'
 end


### PR DESCRIPTION
[Build failing](https://travis-ci.org/razorpay/razorpay-ruby/jobs/290116081) due to [this](https://github.com/bbatsov/rubocop/pull/4874).