### PR TITLE
[rubocop] Fixes build

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,8 @@ Style/ClassVars:
 
 Metrics/MethodLength:
   Max: 15
+
+Naming/UncommunicativeMethodParamName:
+  MinNameLength: 1
+  AllowNamesEndingInNumbers: false
+

--- a/razorpay-ruby.gemspec
+++ b/razorpay-ruby.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'razorpay/constants'
 

--- a/razorpay-ruby.gemspec
+++ b/razorpay-ruby.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('lib', __dir__)
+lib = File.expand_path('lib', Dir.pwd)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'razorpay/constants'
 


### PR DESCRIPTION
[Build fails](https://travis-ci.org/razorpay/razorpay-ruby/jobs/349976090) with Rubocop v0.53.0

Fixes:
- Corrects expand usage. New Cop: https://github.com/bbatsov/rubocop/issues/4008
- Limits `UncommunicativeMethodParamName` cop: New Cop: https://github.com/bbatsov/rubocop/issues/3666
  - This has been configured to allow short names, but not allow names ending with a number, which sounds reasonable to me.