### PR TITLE
[httparty] Extends HTTParty's HashConversions module to use indexed keys for arrays

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,12 +9,14 @@ Metrics/LineLength:
 Style/SymbolArray:
   MinSize: 3
 
-Style/ClassVars:
-  Enabled: false
-
 Metrics/MethodLength:
   Max: 15
 
 Naming/UncommunicativeMethodParamName:
   MinNameLength: 1
   AllowNamesEndingInNumbers: false
+
+# Near-duplicate of a file from an external package, want to keep changes minimal
+AllCops:
+  Exclude:
+    - 'lib/extensions/httparty/hash_conversions.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Changelog for Razorpay-Ruby SDK.
 
 ## Unreleased
+### Changed
+- Use indexed keys in x-www-form-urlencoded request bodies
 
 ## [2.3.0] - 2018-04-20
 ### Added

--- a/lib/extensions/httparty/hash_conversions.rb
+++ b/lib/extensions/httparty/hash_conversions.rb
@@ -1,0 +1,44 @@
+require 'httparty'
+
+# :nocov:
+module HTTParty
+  # Extension of HTTParty:HashConversions. Changes made to add index to arrays
+  # https://github.com/jnunemaker/httparty/blob/master/lib/httparty/hash_conversions.rb#L42,L55
+  module HashConversions
+    def self.normalize_keys(key, value)
+      stack = []
+      normalized_keys = []
+
+      if value.respond_to?(:to_ary)
+        if value.empty?
+          normalized_keys << ["#{key}[]", '']
+        else
+          normalized_keys = value.to_ary.flat_map.with_index do
+            |element, index| normalize_keys("#{key}[#{index}]", element)
+          end
+        end
+      elsif value.respond_to?(:to_hash)
+        stack << [key, value.to_hash]
+      else
+        normalized_keys << [key.to_s, value]
+      end
+
+      stack.each do |parent, hash|
+        hash.each do |child_key, child_value|
+          if child_value.respond_to?(:to_hash)
+            stack << ["#{parent}[#{child_key}]", child_value.to_hash]
+          elsif child_value.respond_to?(:to_ary)
+            child_value.to_ary.each_with_index do |v, index|
+              normalized_keys << normalize_keys("#{parent}[#{child_key}][#{index}]", v).flatten
+            end
+          else
+            normalized_keys << normalize_keys("#{parent}[#{child_key}]", child_value).flatten
+          end
+        end
+      end
+
+      normalized_keys
+    end
+  end
+end
+# :nocov:

--- a/lib/razorpay/request.rb
+++ b/lib/razorpay/request.rb
@@ -1,5 +1,6 @@
-require 'razorpay/constants'
 require 'httparty'
+require 'extensions/httparty/hash_conversions'
+require 'razorpay/constants'
 
 module Razorpay
   # Request objects are used to create fetch

--- a/test/razorpay/test_subscription.rb
+++ b/test/razorpay/test_subscription.rb
@@ -51,6 +51,31 @@ module Razorpay
       assert_subscription_details(subscription)
     end
 
+    def test_subscription_should_be_created_with_upfront_amount
+      subscription_attrs = {
+        plan_id: 'fake_plan_id',
+        total_count: 12,
+        addons: [
+          { item: { amount: 100, currency: 'INR' } },
+          { item: { amount: 200, currency: 'INR' } }
+        ]
+      }
+
+      #
+      # Note that the stubbed request has the addons array
+      # indexed, ensuring that the right request is being built
+      #
+      # This test will fail if the request sends
+      # "addons[][item][amount]=100&addons[][item][currency]=INR" instead
+      #
+      stub_params = 'plan_id=fake_plan_id&total_count=12&' \
+                    'addons[0][item][amount]=100&addons[0][item][currency]=INR&' \
+                    'addons[1][item][amount]=200&addons[1][item][currency]=INR'
+      stub_post(/subscriptions$/, 'fake_subscription', stub_params)
+
+      Razorpay::Subscription.create subscription_attrs
+    end
+
     def test_subscription_can_be_cancelled_by_subscription_id
       stub_post(%r{subscriptions\/#{@subscription_id}\/cancel$}, 'cancel_subscription', {})
       subscription = Razorpay::Subscription.cancel(@subscription_id)

--- a/test/razorpay/test_virtual_account.rb
+++ b/test/razorpay/test_virtual_account.rb
@@ -24,7 +24,7 @@ module Razorpay
       stub_post(
         /virtual_accounts$/,
         'fake_virtual_account',
-        'receiver_types[]=bank_account&description=First%20Virtual%20Account'
+        'receiver_types[0]=bank_account&description=First%20Virtual%20Account'
       )
 
       virtual_account = Razorpay::VirtualAccount.create @virtual_account_create_array


### PR DESCRIPTION
Also adds a test for the indexing bug case

Fixes #50 