### PR TITLE
Version bump (v2.4.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,16 @@ language: ruby
 # Merged with whatever is the top of each branch at https://www.ruby-lang.org/en/downloads/releases/
 matrix:
   include:
-    - rvn: "2.6.1"
-    - rvm: "2.5.3"
-    - rvm: "2.4.5"
+    - rvm: "2.6.2"
+    - rvm: "2.5.5"
+    - rvm: "2.4.6"
       env: LINT=rubocop
   allow_failures:
   # These are EOL versions of ruby
-    - rvm: "1.9.3"
-    - rvm: "2.0.0"
-    - rvm: "2.1.10"
     - rvm: "2.3.8"
+    - rvm: "2.1.10"
+    - rvm: "2.0.0"
+    - rvm: "1.9.3"
 before_install: gem update --system
 script:
   - bundle exec rake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,39 +5,55 @@ Changelog for Razorpay-Ruby SDK.
 ## Unreleased
 
 ## [2.4.0] - 2019-04-08
+
 ### Changed
-- Indexed keys used in x-www-form-urlencoded request bodies
-- Updated Utility verify_* methods to return verification bool
+
+- Indexed keys used in x-www-form-urlencoded request bodies [[#68][68]]
+- Updated Utility verify\_\* methods to return verification bool [[#72][72]]
 
 ### Added
-- Support for custom JSON options to Entity to_json
+
+- Support for custom JSON options to Entity to_json [[#75][75]]
 
 ## [2.3.0] - 2018-04-20
+
 ### Added
+
 - Support for subscription signature verification
 - Bang! methods (`capture!`, `refund!`) that update the calling entity
 
 ## [2.2.0] - 2018-01-29
+
 ### Added
+
 - Support for Subscriptions
 
 ## [2.1.0] - 2017-11-17
+
 ### Changed
+
 - Generic `Razorpay::Error` is thrown when server is unreachable
 
 ### Added
+
 - Support for making raw requests to the API via `raw_request`.
 
 ## [2.1.0.pre] - 2017-08-17
+
 ### Added
+
 - Support for Virtual Accounts
 
 ## [2.0.1] - 2017-07-31
+
 ### Fixed
+
 - Webhook signature verification
 
 ## [2.0.0] - 2017-03-02
+
 ### Added
+
 - Adds `require` for all Razorpay supported entities
 - All entity objects now throw `NoMethodError` instead of `NameError` if the attribute doesn't exist
 - Adds customer edit API
@@ -50,32 +66,45 @@ Changelog for Razorpay-Ruby SDK.
 - Adds rake test groups
 
 ## [1.2.1] - 2016-12-22
+
 ### Changed
+
 - Drops ArgumentError checks for local validation. Rely on server side checks instead.
 
 ### Added
+
 - Support for customers and invoices API
 - Loads Order class by default.
 
 ## [1.2.0] - 2016-11-23
+
 ### Added
+
 - Fixed payment.method as an attribute accessor
 
 ## [1.1.0] - 2016-02-25
+
 ### Added
+
 - Add support for Orders API
 - Bundles the CA Certificate with the gem. See #6
 
 ## [1.0.3] - 2015-03-31
+
 ### Changed
+
 - Handles error requests properly
 
 ## [1.0.1] - 2015-02-23
+
 ### Added
+
 - Added support for ruby versions below 2.0
 
 ## [1.0.0] - 2015-01-17
+
 ### Added
+
 - Initial Release
 
 # Diff
@@ -93,3 +122,7 @@ Changelog for Razorpay-Ruby SDK.
 - [1.1.0](https://github.com/razorpay/razorpay-ruby/compare/1.0.3...1.1.0)
 - [1.0.3](https://github.com/razorpay/razorpay-ruby/compare/1.0.1...1.0.3)
 - [1.0.1](https://github.com/razorpay/razorpay-ruby/compare/1.0.0...1.0.1)
+
+[68]: https://github.com/razorpay/razorpay-ruby/pull/68
+[72]: https://github.com/razorpay/razorpay-ruby/pull/72
+[75]: https://github.com/razorpay/razorpay-ruby/pull/75

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,14 @@
 Changelog for Razorpay-Ruby SDK.
 
 ## Unreleased
+
+## [2.4.0] - 2019-04-08
 ### Changed
-- Use indexed keys in x-www-form-urlencoded request bodies
+- Indexed keys used in x-www-form-urlencoded request bodies
+- Updated Utility verify_* methods to return verification bool
+
+### Added
+- Support for custom JSON options to Entity to_json
 
 ## [2.3.0] - 2018-04-20
 ### Added
@@ -72,15 +78,18 @@ Changelog for Razorpay-Ruby SDK.
 ### Added
 - Initial Release
 
-[Unreleased]: https://github.com/razorpay/razorpay-ruby/compare/2.3.0...HEAD
-[2.3.0]: https://github.com/razorpay/razorpay-ruby/compare/2.2.0...2.3.0
-[2.2.0]: https://github.com/razorpay/razorpay-ruby/compare/2.1.0...2.2.0
-[2.1.0]: https://github.com/razorpay/razorpay-ruby/compare/2.0.1...2.1.0
-[2.1.0.pre]: https://github.com/razorpay/razorpay-ruby/compare/2.0.1...2.1.0.pre
-[2.0.1]: https://github.com/razorpay/razorpay-ruby/compare/2.0.0...2.0.1
-[2.0.0]: https://github.com/razorpay/razorpay-ruby/compare/1.2.1...2.0.0
-[1.2.1]: https://github.com/razorpay/razorpay-ruby/compare/1.2.0...1.2.1
-[1.2.0]: https://github.com/razorpay/razorpay-ruby/compare/1.1.0...1.2.0
-[1.1.0]: https://github.com/razorpay/razorpay-ruby/compare/1.0.3...1.1.0
-[1.0.3]: https://github.com/razorpay/razorpay-ruby/compare/1.0.1...1.0.3
-[1.0.1]: https://github.com/razorpay/razorpay-ruby/compare/1.0.0...1.0.1
+# Diff
+
+- [Unreleased](https://github.com/razorpay/razorpay-ruby/compare/2.4.0...HEAD)
+- [2.4.0](https://github.com/razorpay/razorpay-ruby/compare/2.3.0...2.4.0)
+- [2.3.0](https://github.com/razorpay/razorpay-ruby/compare/2.2.0...2.3.0)
+- [2.2.0](https://github.com/razorpay/razorpay-ruby/compare/2.1.0...2.2.0)
+- [2.1.0](https://github.com/razorpay/razorpay-ruby/compare/2.0.1...2.1.0)
+- [2.1.0.pre](https://github.com/razorpay/razorpay-ruby/compare/2.0.1...2.1.0.pre)
+- [2.0.1](https://github.com/razorpay/razorpay-ruby/compare/2.0.0...2.0.1)
+- [2.0.0](https://github.com/razorpay/razorpay-ruby/compare/1.2.1...2.0.0)
+- [1.2.1](https://github.com/razorpay/razorpay-ruby/compare/1.2.0...1.2.1)
+- [1.2.0](https://github.com/razorpay/razorpay-ruby/compare/1.1.0...1.2.0)
+- [1.1.0](https://github.com/razorpay/razorpay-ruby/compare/1.0.3...1.1.0)
+- [1.0.3](https://github.com/razorpay/razorpay-ruby/compare/1.0.1...1.0.3)
+- [1.0.1](https://github.com/razorpay/razorpay-ruby/compare/1.0.0...1.0.1)

--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ only, the code is tested against the following versions:
 * 1.9.3
 * 2.0.0
 * 2.1.10
-* 2.2.9
-* 2.3.6
-* 2.4.2
-* 2.5.0
+* 2.3.8
+* 2.4.6
+* 2.5.5
+* 2.6.2
 
 ## Release
 

--- a/lib/razorpay/constants.rb
+++ b/lib/razorpay/constants.rb
@@ -2,5 +2,5 @@
 module Razorpay
   BASE_URI = 'https://api.razorpay.com/v1/'.freeze
   TEST_URL = 'https://api.razorpay.com/'.freeze
-  VERSION = '2.3.0'.freeze
+  VERSION = '2.4.0'.freeze
 end


### PR DESCRIPTION
New stuff:
- [Indexed keys](https://github.com/razorpay/razorpay-ruby/pull/68)
- [`to_json` with options](https://github.com/razorpay/razorpay-ruby/pull/75)
- [Return value for utility verify_* methods](https://github.com/razorpay/razorpay-ruby/pull/72)

This PR also contains other changes.
- Updated Ruby tested versions to use latest minor of each dev branch [here](https://www.ruby-lang.org/en/downloads/releases/)
- Formatting fixes in the changelog to make diff visible