### PR TITLE
payment doc correction

### DIFF
--- a/documents/payment.md
+++ b/documents/payment.md
@@ -81,7 +81,7 @@ Razorpay::Payment.all(option)
 | to    | timestamp | timestamp before which the payments were created |
 | count | integer   | number of payments to fetch (default: 10)        |
 | skip  | integer   | number of payments to be skipped (default: 0)    |
-| expand[]  | array   | Supported values are: -card: Expanded card details, usable for card and EMI payments. -emi: Expanded EMI plan details, usable for EMI payments    |
+| expand[]  | string   | Supported values are: -card: Expanded card details, usable for card and EMI payments. -emi: Expanded EMI plan details, usable for EMI payments    |
 
 
 **Response:**
@@ -255,8 +255,8 @@ Razorpay::Payment.fetch(paymentId).edit(para_attr)
 
 | Name        | Type    | Description                          |
 |-------------|---------|--------------------------------------|
-| paymentId* | string  | Id of the payment to update          |
-| notes*       | object  | A key-value pair                     |
+| paymentId* | string  | Id of the payment to update           |
+| notes*       | object  | A key-value pair                    |
 
 **Response:**
 ```json
@@ -401,7 +401,8 @@ Razorpay::Order.create(para_attr)
 | amount*          | integer | Amount of the order to be paid                                               |
 | currency*        | string  | Currency of the order. Currently only `INR` is supported.       |
 | receipt         | string  | Your system order reference id.                                              |
-| payment         | object  | please refer this [doc](https://razorpay.com/docs/payments/payments/capture-settings/api/) for params                       |
+| payment         | object  | please refer this [doc](https://razorpay.com/docs/payments/payments/capture-settings/api/) for params  |
+| notes | object  | A key-value pair  |
 
 **Response:** <br>
 ```json
@@ -497,12 +498,12 @@ Razorpay::Payment.create_json_payment(para_attr)
 | email*        | string      | Email of the customer                       |
 | contact*      | string      | Contact number of the customer              |
 | method*      | string  | Possible value is `card`, `netbanking`, `wallet`,`emi`, `upi`, `cardless_emi`, `paylater`.  |
-| card      | array      | All keys listed [here](https://razorpay.com/docs/payments/payment-gateway/s2s-integration/payment-methods/#supported-payment-fields) are supported  |
+| card      | object      | All keys listed [here](https://razorpay.com/docs/payments/payment-gateway/s2s-integration/payment-methods/#supported-payment-fields) are supported  |
 | bank      | string      | Bank code of the bank used for the payment. Required if the method is `netbanking`.|
-| bank_account | array      | All keys listed [here](https://razorpay.com/docs/payments/customers/customer-fund-account-api/#create-a-fund-account) are supported |
+| bank_account | object      | All keys listed [here](https://razorpay.com/docs/payments/customers/customer-fund-account-api/#create-a-fund-account) are supported |
 | vpa      | string      | Virtual payment address of the customer. Required if the method is `upi`. |
 | wallet | string      | Wallet code for the wallet used for the payment. Required if the method is `wallet`. |
-| notes | array  | A key-value pair  |
+| notes | object  | A key-value pair  |
 
  please refer this [doc](https://razorpay.com/docs/payment-gateway/s2s-integration/payment-methods/) for params
 


### PR DESCRIPTION
[Payment capture setting api ](https://docs.google.com/spreadsheets/d/1FwFHxOY994oS6jCmPd4ubdC4Itbr5QGaRg24_O6xj4U/edit#gid=0&range=A35): 
[update](https://github.com/razorpay/razorpay-ruby/blob/payment_doc_correction/documents/payment.md?plain=1#L405)

[Update a payment](https://docs.google.com/spreadsheets/d/1FwFHxOY994oS6jCmPd4ubdC4Itbr5QGaRg24_O6xj4U/edit#gid=0&range=A30) : [update](https://github.com/razorpay/razorpay-ruby/blob/payment_doc_correction/documents/payment.md?plain=1#L251) variable is already `paymentId`
