### PR TITLE
fix exception

### DIFF
--- a/lib/razorpay/request.rb
+++ b/lib/razorpay/request.rb
@@ -130,7 +130,9 @@ module Razorpay
       raise klass.new(*args), error['description']
     rescue NameError, LoadError
       # We got an unknown error, cast it to Error for now
-      raise Razorpay::Error.new, 'Unknown Error'
+      code = error['code'] rescue nil
+      description = error['description'] rescue 'Unknown Error'
+      raise Razorpay::Error.new(code, status), description || 'Unknown Error'
     end
   end
 end


### PR DESCRIPTION
Make the Code key optional, as it may not be present in the get access token exception response.