### PR TITLE
chore: upgrade to Ruby 3.2+ and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,17 @@ jobs:
   runs-on: ubuntu-latest
 
   steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - name: Set up Ruby
     uses: ruby/setup-ruby@v1
     with:
-      ruby-version:  3.1
+      ruby-version: '3.3'
   - name: Install dependencies
     run: bundle install
   - name: Build
     run: gem build *.gemspec
   - name: 'Upload Artifact'
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: gems
       path: '*.gem'
@@ -33,41 +33,41 @@ jobs:
   needs: build
   strategy:
    matrix:
-    ruby-version: ['2.6', '2.7', '3.0', '3.1']
+    ruby-version: ['3.0', '3.1', '3.2', '3.3']
 
   steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set up Ruby latest
+      uses: actions/checkout@v4
+    - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: ${{ matrix.ruby-version }}
     - name: Install dependencies
       run: bundle install
     - name: Run tests and collect coverage
       run: bundle exec rake
     - name: Upload coverage to Codecov
-      if: ${{ matrix.ruby-version == 3.1 }}
-      uses: codecov/codecov-action@v3
+      if: ${{ matrix.ruby-version == '3.3' }}
+      uses: codecov/codecov-action@v4
       with:
         files: ${{ github.workspace }}/coverage/coverage.xml
- publish:      
+ publish:
     name: Publish
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build, test]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: sudo apt-get install -y oathtool
     - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: gems
         path: gems
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version:  3.1
+        ruby-version: '3.3'
     - name: Publish gems to Rubygems
       run: |
        mkdir -p $HOME/.gem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   - name: Set up Ruby
     uses: ruby/setup-ruby@v1
     with:
-      ruby-version: '3.3'
+      ruby-version: '4.0'
   - name: Install dependencies
     run: bundle install
   - name: Build
@@ -33,7 +33,7 @@ jobs:
   needs: build
   strategy:
    matrix:
-    ruby-version: ['3.0', '3.1', '3.2', '3.3']
+    ruby-version: ['3.2', '3.3', '3.4', '4.0']
 
   steps:
     - name: Checkout
@@ -47,7 +47,7 @@ jobs:
     - name: Run tests and collect coverage
       run: bundle exec rake
     - name: Upload coverage to Codecov
-      if: ${{ matrix.ruby-version == '3.3' }}
+      if: ${{ matrix.ruby-version == '4.0' }}
       uses: codecov/codecov-action@v4
       with:
         files: ${{ github.workspace }}/coverage/coverage.xml
@@ -67,7 +67,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: '4.0'
     - name: Publish gems to Rubygems
       run: |
        mkdir -p $HOME/.gem

--- a/razorpay-ruby.gemspec
+++ b/razorpay-ruby.gemspec
@@ -12,26 +12,19 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://razorpay.com/'
   spec.license       = 'MIT'
 
+  spec.required_ruby_version = '>= 3.0.0'
+
   spec.files         = `git ls-files`.split("\n")
   spec.executables   = spec.files.grep(/^bin/) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(/^(test|spec|features)/)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'httparty', '~> 0.14'
+  spec.add_dependency 'httparty', '~> 0.22'
 
-  spec.add_development_dependency 'coveralls_reborn', '~> 0.8'
-  spec.add_development_dependency 'minitest', '~> 5.11'
-  spec.add_development_dependency 'rake', '~> 12.0'
-
-  if RUBY_VERSION >= '2.1.0'
-    # rubocop is only run in the latest ruby build
-    # so we use the latest version and don't switch to a
-    # older version for 1.9.3
-    spec.add_development_dependency 'simplecov-cobertura'
-    spec.add_development_dependency 'rubocop', '~> 0.49'
-    spec.add_development_dependency 'webmock', '~> 3.0'
-  else
-    # Webmock 3.0 does not support Ruby 1.9.3
-    spec.add_development_dependency 'webmock', '~> 2.3'
-  end
+  spec.add_development_dependency 'coveralls_reborn', '~> 0.28'
+  spec.add_development_dependency 'minitest', '~> 5.25'
+  spec.add_development_dependency 'rake', '~> 13.2'
+  spec.add_development_dependency 'simplecov-cobertura'
+  spec.add_development_dependency 'rubocop', '~> 1.68'
+  spec.add_development_dependency 'webmock', '~> 3.24'
 end

--- a/razorpay-ruby.gemspec
+++ b/razorpay-ruby.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://razorpay.com/'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.2.0'
 
   spec.files         = `git ls-files`.split("\n")
   spec.executables   = spec.files.grep(/^bin/) { |f| File.basename(f) }

--- a/razorpay-ruby.gemspec
+++ b/razorpay-ruby.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'coveralls_reborn', '~> 0.28'
   spec.add_development_dependency 'minitest', '~> 5.25'
+  spec.add_development_dependency 'ostruct'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'simplecov-cobertura'
   spec.add_development_dependency 'rubocop', '~> 1.68'


### PR DESCRIPTION
## Summary
- Upgrade minimum Ruby version from 2.6 to 3.2
- Update supported versions: 3.2, 3.3, 3.4, 4.0
- Update GitHub Actions from v2/v3 to v4
- Fix CI matrix bug (was ignoring matrix.ruby-version)
- Update dependencies to latest versions:
  - HTTParty 0.14 → 0.22
  - Minitest 5.11 → 5.25
  - Rake 12.0 → 13.2
  - Rubocop 0.49 → 1.68
  - Webmock 3.0 → 3.24
  - coveralls_reborn 0.8 → 0.28
- Remove Ruby 1.9.3/2.1 compatibility code

## Test plan
- [ ] CI passes on Ruby 3.2, 3.3, 3.4, 4.0
- [ ] Existing tests continue to pass
- [ ] Gem builds and publishes correctly

🤖 Generated with [Claude Code](https://claude.ai/code)