### PR TITLE
test: add negative-path crypto utility tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,17 @@ jobs:
   runs-on: ubuntu-latest
 
   steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - name: Set up Ruby
     uses: ruby/setup-ruby@v1
     with:
-      ruby-version:  3.1
+      ruby-version: '4.0'
   - name: Install dependencies
     run: bundle install
   - name: Build
     run: gem build *.gemspec
   - name: 'Upload Artifact'
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: gems
       path: '*.gem'
@@ -33,41 +33,41 @@ jobs:
   needs: build
   strategy:
    matrix:
-    ruby-version: ['2.6', '2.7', '3.0', '3.1']
+    ruby-version: ['3.2', '3.3', '3.4', '4.0']
 
   steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set up Ruby latest
+      uses: actions/checkout@v4
+    - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: ${{ matrix.ruby-version }}
     - name: Install dependencies
       run: bundle install
     - name: Run tests and collect coverage
       run: bundle exec rake
     - name: Upload coverage to Codecov
-      if: ${{ matrix.ruby-version == 3.1 }}
-      uses: codecov/codecov-action@v3
+      if: ${{ matrix.ruby-version == '4.0' }}
+      uses: codecov/codecov-action@v4
       with:
         files: ${{ github.workspace }}/coverage/coverage.xml
- publish:      
+ publish:
     name: Publish
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build, test]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: sudo apt-get install -y oathtool
     - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: gems
         path: gems
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version:  3.1
+        ruby-version: '4.0'
     - name: Publish gems to Rubygems
       run: |
        mkdir -p $HOME/.gem

--- a/razorpay-ruby.gemspec
+++ b/razorpay-ruby.gemspec
@@ -19,19 +19,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'httparty', '~> 0.14'
 
-  spec.add_development_dependency 'coveralls_reborn', '~> 0.8'
-  spec.add_development_dependency 'minitest', '~> 5.11'
-  spec.add_development_dependency 'rake', '~> 12.0'
-
-  if RUBY_VERSION >= '2.1.0'
-    # rubocop is only run in the latest ruby build
-    # so we use the latest version and don't switch to a
-    # older version for 1.9.3
-    spec.add_development_dependency 'simplecov-cobertura'
-    spec.add_development_dependency 'rubocop', '~> 0.49'
-    spec.add_development_dependency 'webmock', '~> 3.0'
-  else
-    # Webmock 3.0 does not support Ruby 1.9.3
-    spec.add_development_dependency 'webmock', '~> 2.3'
-  end
+  spec.add_development_dependency 'coveralls_reborn', '~> 0.28'
+  spec.add_development_dependency 'minitest', '~> 5.25'
+  spec.add_development_dependency 'ostruct'
+  spec.add_development_dependency 'rake', '~> 13.2'
+  spec.add_development_dependency 'simplecov-cobertura'
+  spec.add_development_dependency 'rubocop', '~> 1.68'
+  spec.add_development_dependency 'webmock', '~> 3.24'
 end

--- a/test/razorpay/test_utility_negative.rb
+++ b/test/razorpay/test_utility_negative.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+require 'openssl'
+
+module Razorpay
+  class RazorpayUtilityNegativeTest < Minitest::Test
+    def setup
+      Razorpay.setup('key_id', 'key_secret')
+      @webhook_payload = '{"event":"payment.authorized"}'
+      @webhook_secret = 'test_webhook_secret'
+    end
+
+    def compute_signature(payload, secret)
+      OpenSSL::HMAC.hexdigest('sha256', secret, payload)
+    end
+
+    def test_empty_signature_rejected
+      assert_raises(SecurityError) do
+        Razorpay::Utility.verify_webhook_signature(@webhook_payload, '', @webhook_secret)
+      end
+    end
+
+    def test_wrong_length_signature_rejected
+      assert_raises(SecurityError) do
+        Razorpay::Utility.verify_webhook_signature(@webhook_payload, 'abc123', @webhook_secret)
+      end
+    end
+
+    # Rejected because value doesn't match, not because SDK validates hex format
+    def test_wrong_value_signature_rejected
+      wrong_sig = 'z' * 64
+      assert_raises(SecurityError) do
+        Razorpay::Utility.verify_webhook_signature(@webhook_payload, wrong_sig, @webhook_secret)
+      end
+    end
+
+    def test_tampered_valid_hex_signature_rejected
+      tampered_sig = 'a' * 64
+      assert_raises(SecurityError) do
+        Razorpay::Utility.verify_webhook_signature(@webhook_payload, tampered_sig, @webhook_secret)
+      end
+    end
+
+    def test_valid_dynamic_signature_accepted
+      valid_sig = compute_signature(@webhook_payload, @webhook_secret)
+      result = Razorpay::Utility.verify_webhook_signature(@webhook_payload, valid_sig, @webhook_secret)
+      assert(result)
+    end
+
+    def test_special_chars_in_payload
+      special_payload = '{"event":"payment","data":{"notes":"Test & <script>alert(1)</script>"}}'
+      valid_sig = compute_signature(special_payload, @webhook_secret)
+      result = Razorpay::Utility.verify_webhook_signature(special_payload, valid_sig, @webhook_secret)
+      assert(result)
+    end
+
+    def test_unicode_in_payload
+      unicode_payload = '{"event":"payment","data":{"name":"日本語テスト"}}'
+      valid_sig = compute_signature(unicode_payload, @webhook_secret)
+      result = Razorpay::Utility.verify_webhook_signature(unicode_payload, valid_sig, @webhook_secret)
+      assert(result)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add comprehensive negative-path tests for signature verification utilities:
- Empty signature rejection
- Wrong length signature rejection  
- Wrong value signature rejection (not hex validation)
- Tampered valid-hex signature rejection
- Valid dynamic signature acceptance
- Special characters in payload
- Unicode characters in payload (multi-byte UTF-8)

Also includes CI and gemspec updates for independent mergeability:
- Update GitHub Actions to v4
- Update test matrix: 3.2, 3.3, 3.4, 4.0
- Add ostruct gem for Ruby 4.0 compatibility
- Update dev dependencies

## Test plan
- [ ] All new tests pass
- [ ] CI passes on Ruby 3.2, 3.3, 3.4, 4.0
- [ ] Coverage maintained or improved

🤖 Generated with [Claude Code](https://claude.ai/code)