### PR TITLE
ci: upgrade GitHub Actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,17 @@ jobs:
   runs-on: ubuntu-latest
 
   steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - name: Set up Ruby
     uses: ruby/setup-ruby@v1
     with:
-      ruby-version:  3.1
+      ruby-version: '3.1'
   - name: Install dependencies
     run: bundle install
   - name: Build
     run: gem build *.gemspec
   - name: 'Upload Artifact'
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: gems
       path: '*.gem'
@@ -37,37 +37,37 @@ jobs:
 
   steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set up Ruby latest
+      uses: actions/checkout@v4
+    - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: ${{ matrix.ruby-version }}
     - name: Install dependencies
       run: bundle install
     - name: Run tests and collect coverage
       run: bundle exec rake
     - name: Upload coverage to Codecov
-      if: ${{ matrix.ruby-version == 3.1 }}
-      uses: codecov/codecov-action@v3
+      if: ${{ matrix.ruby-version == '3.1' }}
+      uses: codecov/codecov-action@v4
       with:
         files: ${{ github.workspace }}/coverage/coverage.xml
- publish:      
+ publish:
     name: Publish
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build, test]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: sudo apt-get install -y oathtool
     - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: gems
         path: gems
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version:  3.1
+        ruby-version: '3.1'
     - name: Publish gems to Rubygems
       run: |
        mkdir -p $HOME/.gem


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions from v2/v3 to v4 (v3 is deprecated)
- Fix CI matrix bug (was hardcoding ruby-version: 3.1 instead of using matrix.ruby-version)

**This PR must be merged first** before other PRs that update Ruby versions, as GitHub runs the base branch's workflow against PRs.

## Test plan
- [ ] CI passes on Ruby 2.6, 2.7, 3.0, 3.1

🤖 Generated with [Claude Code](https://claude.ai/code)