### PR TITLE
version-bump v3.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for Razorpay-Ruby SDK.
 
 ## Unreleased
 
+## [3.2.4] - 2026-06-08
+
+fix: Security fix for AES-GCM onboarding signature
+* Fixed nonce reuse vulnerability in `generate_onboarding_signature` by using a random nonce per call instead of a static IV derived from the secret key
+* New output format: `hex(iv[12] || ciphertext || tag[16])` — the receiver reads the first 24 hex chars as the IV before decrypting
+
 ## [3.2.3] - 2024-05-27
 
 feat: Added new API endpoints

--- a/lib/razorpay/constants.rb
+++ b/lib/razorpay/constants.rb
@@ -2,7 +2,7 @@
 module Razorpay
   BASE_URI = 'https://api.razorpay.com'.freeze
   TEST_URL = 'https://api.razorpay.com/'.freeze
-  VERSION  = '3.2.3'.freeze
+  VERSION  = '3.2.4'.freeze
   AUTH_URL = 'https://auth.razorpay.com'.freeze
   API_HOST = 'API'.freeze
   AUTH_HOST    = 'AUTH'.freeze


### PR DESCRIPTION
## Summary
- Bumps version from 3.2.3 → 3.2.4
- Updates CHANGELOG with fix from PR #270

## Test plan
- [ ] Verify `Razorpay::VERSION` returns `3.2.4`
- [ ] Confirm `generate_onboarding_signature` produces output in new format: `hex(iv || ciphertext || tag)`
- [ ] Run full test suite (`bundle exec rake`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)