### PR TITLE
Hashirr/handle missing error key

### DIFF
--- a/lib/razorpay/request.rb
+++ b/lib/razorpay/request.rb
@@ -106,11 +106,11 @@ module Razorpay
       end
 
     # Normalize OAuth string error format into Razorpay's standard hash format
-      if response.is_a?(Hash) && response['error'].is_a?(String)
+      if response.is_a?(Hash) && response['error'].is_a?(Hash)
         response = {
           'error' => {
             'code' => 'BAD_REQUEST_ERROR',
-            'description' => response['error_description'] || response['error']
+            'description' => response['error']['description']
           }
         }
       end
@@ -131,6 +131,7 @@ module Razorpay
     end
 
     def raise_error(error, status)
+
       # Get the error class name, require it and instantiate an error
       class_name = error['code'].split('_').map(&:capitalize).join('')
       args = [error['code'], status]

--- a/lib/razorpay/request.rb
+++ b/lib/razorpay/request.rb
@@ -27,8 +27,8 @@ module Razorpay
           timeout: 30,
           headers: headers
         }
-        headers['Authorization'] = 'Bearer ' + Razorpay.access_token 
-      else 
+        headers['Authorization'] = 'Bearer ' + Razorpay.access_token
+      else
         @options = {
           basic_auth: Razorpay.auth,
           timeout: 30,
@@ -52,7 +52,7 @@ module Razorpay
     def get(url, data = {}, version="v1")
       request :get, "/#{version}/#{@entity_name}/#{url}", data
     end
-    
+
     def delete(url, version="v1")
       request :delete, "/#{version}/#{@entity_name}/#{url}"
     end
@@ -73,21 +73,21 @@ module Razorpay
       create_instance raw_request(method, url, data)
     end
 
-    def raw_request(method, url, data = {}) 
+    def raw_request(method, url, data = {})
       case method
       when :get
         @options[:query] = data
       when :post, :put, :patch
         @options[:body] = data
       end
-      
+
       self.class.send(method, url, @options)
     end
 
     def get_base_url(host)
       if host == Razorpay::AUTH_HOST
         return Razorpay::AUTH_URL
-      end 
+      end
       Razorpay::BASE_URI
     end
 
@@ -103,8 +103,18 @@ module Razorpay
 
       if response.is_a?(Array)==true || response.to_s.length == 0
         return response
-      end 
-      
+      end
+
+    # Normalize OAuth string error format into Razorpay's standard hash format
+      if response.is_a?(Hash) && response['error'].is_a?(String)
+        response = {
+          'error' => {
+            'code' => 'BAD_REQUEST_ERROR',
+            'description' => response['error_description'] || response['error']
+          }
+        }
+      end
+
       # if there was an error, throw it
       raise_error(response['error'], res.code) if response.nil? || response.key?('error') && res.code !=200
       # There must be a top level entity

--- a/lib/razorpay/request.rb
+++ b/lib/razorpay/request.rb
@@ -101,6 +101,19 @@ module Razorpay
     def create_instance(res)
       response = res.parsed_response
 
+      # Any non-2xx must raise a Razorpay error regardless of body shape.
+      # Guards against empty bodies and hash bodies without the expected `error` wrapper.
+      if res.code.to_i >= 400 && !(response.is_a?(Hash) && response.key?('error'))
+        description = if response.is_a?(Hash)
+                        response['description'] || response['message'] || response.to_json
+                      elsif response.to_s.strip.empty?
+                        "HTTP #{res.code}"
+                      else
+                        response.to_s[0, 500]
+                      end
+        raise_error({'code' => 'BAD_REQUEST_ERROR', 'description' => description}, res.code)
+      end
+
       if response.is_a?(Array)==true || response.to_s.length == 0
         return response
       end

--- a/lib/razorpay/request.rb
+++ b/lib/razorpay/request.rb
@@ -105,14 +105,20 @@ module Razorpay
         return response
       end
 
-    # Normalize OAuth string error format into Razorpay's standard hash format
-      if response.is_a?(Hash) && response['error'].is_a?(Hash)
-        response = {
-          'error' => {
-            'code' => 'BAD_REQUEST_ERROR',
-            'description' => response['error']['description']
+    # Normalize OAuth error responses into Razorpay's standard format.
+    # The auth host returns {"error": {"description": "..."}} without a code on 400,
+    # and {"error": "string", "error_description": "..."} on 401.
+      if response.is_a?(Hash)
+        if response['error'].is_a?(String)
+          response = {
+            'error' => {
+              'code' => 'BAD_REQUEST_ERROR',
+              'description' => response['error_description'] || response['error']
+            }
           }
-        }
+        elsif response['error'].is_a?(Hash) && !response['error'].key?('code')
+          response['error']['code'] = 'BAD_REQUEST_ERROR'
+        end
       end
 
       # if there was an error, throw it
@@ -131,8 +137,10 @@ module Razorpay
     end
 
     def raise_error(error, status)
+      unless error.is_a?(Hash) && error['code']
+        raise Razorpay::Error.new, error.is_a?(Hash) ? (error['description'] || 'Unknown Error') : error.to_s
+      end
 
-      # Get the error class name, require it and instantiate an error
       class_name = error['code'].split('_').map(&:capitalize).join('')
       args = [error['code'], status]
       args.push error['field'] if error.key?('field')


### PR DESCRIPTION
## Summary
Razorpay 401 responses sometimes omit the expected `{"error": {...}}` wrapper. When that happens, `create_instance` falls through to `Razorpay::Entity.new(response)` and callers crash with `NoMethodError: undefined method 'id' for an instance of Razorpay::Entity`.

This adds a guard that turns any non-2xx response into a `Razorpay::BadRequestError` regardless of body shape (empty body, plain-text from upstream proxies, hash without the error wrapper). Callers can rescue cleanly, and the OAuth refresh retry path fires as intended.

## Test plan
- [ ] Existing gem specs pass
- [ ] With an invalid OAuth token, `Razorpay::Customer.fetch(id)` raises `Razorpay::BadRequestError` (not `NoMethodError`)